### PR TITLE
CO Do not send Order Reference to anyone

### DIFF
--- a/controllers/front/ContactController.php
+++ b/controllers/front/ContactController.php
@@ -290,7 +290,9 @@ class ContactControllerCore extends FrontController
     protected function getOrder()
     {
         $id_order = false;
-        if (!is_numeric($reference = Tools::getValue('id_order'))) {
+        if(is_numeric($reference = Tools::getValue('id_order')) {
+            return false
+        } else if (!is_numeric($reference = Tools::getValue('id_order'))) {
             $reference = ltrim($reference, '#');
             $orders = Order::getByReference($reference);
             if ($orders) {
@@ -299,8 +301,6 @@ class ContactControllerCore extends FrontController
                     break;
                 }
             }
-        } elseif (Order::getCartIdStatic((int)Tools::getValue('id_order'))) {
-            $id_order = (int)Tools::getValue('id_order');
         }
         return (int)$id_order;
     }


### PR DESCRIPTION
Anyone can retrieve the reference of an order

I let you imagine the kind of email you send to a shop with this reference !

"Plz change délivery adress for this reference !"

Reference on demoshop 

Order 1 => XKBKNABJK
Order 2 => OHSATSERP


