### PR TITLE
BO: Allow Hour in specific Price

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -67,7 +67,8 @@ $(document).ready(function() {
   /** Attach date picker */
   $('.datepicker').datetimepicker({
     locale: iso_user,
-    format: 'YYYY-MM-DD'
+    format: 'YYYY-MM-DD HH:mm:ss',
+    sideBySide: true
   });
 
   /** tooltips should be hidden when we move to another tab */


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Allow Hour Minutes secondes in specific price ( product )
| Type?         | bug fix / improvement / new feature
| Category?     | BO
| How to test?  | Go to product -> Price Add specific price -> Select Date

It's the best way i found but not perfectly;  if people say me how to set icon ?

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
